### PR TITLE
fix/update-gitignore: add instruction (.idea) to ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+.idea
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
- The inclusion of files in /.idea folder does not offer significant advantages.
- This PR removes that folder from future pushes by adding that path into .gitignore file